### PR TITLE
Fix for #9

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,16 +8,19 @@ var debug = require('debug')('detective-sass');
  * @param  {String} fileContent
  * @return {String[]}
  */
-module.exports = function detective(fileContent) {
+module.exports = function detective(fileContent, opts) {
   if (typeof fileContent === 'undefined') { throw new Error('content not given'); }
   if (typeof fileContent !== 'string') { throw new Error('content is not a string'); }
+  if (Object.prototype.toString.call(opts) !== '[object Object]') { opts = {}; }
 
   var dependencies = [];
   var ast;
 
   try {
     debug('content: ' + fileContent);
-    ast = sass.parse(fileContent);
+    ast = sass.parse(fileContent, {
+      syntax: opts.syntax || 'sass'
+    });
   } catch (e) {
     debug('parse error: ', e.message);
     ast = {};

--- a/test/test.js
+++ b/test/test.js
@@ -2,8 +2,8 @@ var detective = require('../');
 var assert = require('assert');
 
 describe('detective-sass', function() {
-  function test(src, deps) {
-    assert.deepEqual(detective(src), deps);
+  function test(src, deps, opts) {
+    assert.deepEqual(detective(src, opts), deps);
   }
 
   describe('throws', function() {
@@ -46,20 +46,27 @@ describe('detective-sass', function() {
 
   describe('scss', function() {
     it('returns the dependencies of the given .scss file content', function() {
-      test('@import "_foo.scss";', ['_foo.scss']);
-      test('@import          "_foo.scss";', ['_foo.scss']);
-      test('@import "_foo";', ['_foo']);
-      test('body { color: blue; } @import "_foo";', ['_foo']);
-      test('@import "bar";', ['bar']);
-      test('@import "bar"; @import "foo";', ['bar', 'foo']);
-      test('@import \'bar\';', ['bar']);
-      test('@import \'bar.scss\';', ['bar.scss']);
-      test('@import "_foo.scss";\n@import "_bar.scss";', ['_foo.scss', '_bar.scss']);
-      test('@import "_foo.scss";\n@import "_bar.scss";\n@import "_baz";\n@import "_buttons";', ['_foo.scss', '_bar.scss', '_baz', '_buttons']);
+      var scssOpts = {
+        syntax: 'scss'
+      };
+
+      test('@import "_foo.scss";', ['_foo.scss'], scssOpts);
+      test('@import          "_foo.scss";', ['_foo.scss'], scssOpts);
+      test('@import "_foo";', ['_foo'], scssOpts);
+      test('body { color: blue; } @import "_foo";', ['_foo'], scssOpts);
+      test('@import "bar";', ['bar'], scssOpts);
+      test('@import "bar"; @import "foo";', ['bar', 'foo'], scssOpts);
+      test('@import \'bar\';', ['bar'], scssOpts);
+      test('@import \'bar.scss\';', ['bar.scss'], scssOpts);
+      test('@import "_foo.scss";\n@import "_bar.scss";', ['_foo.scss', '_bar.scss'], scssOpts);
+      test('@import "_foo.scss";\n@import "_bar.scss";\n@import "_baz";\n@import "_buttons";', ['_foo.scss', '_bar.scss', '_baz', '_buttons'], scssOpts);
+      test('@import "_nested.scss"; body { color: blue; a { text-decoration: underline; }}', ['_nested.scss'], scssOpts);
     });
 
     it('handles comma-separated imports (#2)', function() {
-      test('@import "_foo.scss", "bar";', ['_foo.scss', 'bar']);
+      test('@import "_foo.scss", "bar";', ['_foo.scss', 'bar'], {
+        syntax: 'scss'
+      });
     });
 
     it('allows imports with no semicolon', function() {


### PR DESCRIPTION
Adds optional second parameter to specify which syntax to parse the passed in content as (note: this value is passed through to `gonzales-pe`)

This change includes a new test case but doesn't bump version or make changes to README -- wanted to see if you wanted to handle those change separately or to include them in this PR.