### PR TITLE
BREAKING: Remove scss support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,10 @@
 ### detective-sass [![npm](http://img.shields.io/npm/v/detective-sass.svg)](https://npmjs.org/package/detective-sass) [![npm](http://img.shields.io/npm/dm/detective-sass.svg)](https://npmjs.org/package/detective-sass)
 
-> Find the dependencies of a sass/scss file
+> Find the dependencies of a sass file
 
 `npm install --save detective-sass`
+
+**Note:** This is specific to the .sass style syntax of the Sass preprocessor. For SCSS support, please see [node-detective-scss](https://github.com/dependents/node-detective-scss)
 
 It's the SASS counterpart to [detective](https://github.com/substack/node-detective), [detective-amd](https://github.com/mrjoelkemp/node-detective-amd), and [detective-es6](https://github.com/mrjoelkemp/node-detective-es6).
 
@@ -13,29 +15,16 @@ It's the SASS counterpart to [detective](https://github.com/substack/node-detect
 ```js
 var detective = require('detective-sass');
 
-var content = fs.readFileSync('styles.scss', 'utf8');
+var content = fs.readFileSync('styles.sass', 'utf8');
 
-// list of imported file names (ex: '_foo.scss', '_foo', etc)
+// list of imported file names (ex: '_foo.sass', '_foo', etc)
 var dependencies = detective(content);
 ```
 
-You can also supply an *optional* set of configuration options as the second argument to `detective`:
-
-```
-var dependencies = detective(content, {
-  syntax: 'sass'
-});
-```
-
-Options you can specify:
-
-* `syntax`: The syntax of the file. Instructs the parser which language to expect.
- - Possible values: `sass` (default) or `scss`
- - See the [parser's documentation](https://github.com/tonyganch/gonzales-pe#parameters-1) for more details.
-
 ### Related
 
-Check out [node-sass-lookup](https://github.com/dependents/node-sass-lookup) if you want to map a sass/scss dependency to a file on your filesystem.
+* [node-sass-lookup](https://github.com/dependents/node-sass-lookup) if you want to map a sass/scss dependency to a file on your filesystem.
+* [node-precinct](https://github.com/dependents/node-precinct) if you want to also support finding dependencies for JavaScript and other languages.
 
 ### License
 

--- a/index.js
+++ b/index.js
@@ -8,19 +8,16 @@ var debug = require('debug')('detective-sass');
  * @param  {String} fileContent
  * @return {String[]}
  */
-module.exports = function detective(fileContent, opts) {
+module.exports = function detective(fileContent) {
   if (typeof fileContent === 'undefined') { throw new Error('content not given'); }
   if (typeof fileContent !== 'string') { throw new Error('content is not a string'); }
-  if (Object.prototype.toString.call(opts) !== '[object Object]') { opts = {}; }
 
   var dependencies = [];
   var ast;
 
   try {
     debug('content: ' + fileContent);
-    ast = sass.parse(fileContent, {
-      syntax: opts.syntax || 'sass'
-    });
+    ast = sass.parse(fileContent, { syntax: 'sass' });
   } catch (e) {
     debug('parse error: ', e.message);
     ast = {};

--- a/test/test.js
+++ b/test/test.js
@@ -33,7 +33,7 @@ describe('detective-sass', function() {
   });
 
   it('dangles the parsed AST', function() {
-    detective('@import "_foo.scss";');
+    detective('@import "_foo.sass";');
     assert.ok(detective.ast);
   });
 
@@ -41,36 +41,6 @@ describe('detective-sass', function() {
     it('supplies an empty object as the "parsed" ast', function() {
       detective('|');
       assert.deepEqual(detective.ast, {});
-    });
-  });
-
-  describe('scss', function() {
-    it('returns the dependencies of the given .scss file content', function() {
-      var scssOpts = {
-        syntax: 'scss'
-      };
-
-      test('@import "_foo.scss";', ['_foo.scss'], scssOpts);
-      test('@import          "_foo.scss";', ['_foo.scss'], scssOpts);
-      test('@import "_foo";', ['_foo'], scssOpts);
-      test('body { color: blue; } @import "_foo";', ['_foo'], scssOpts);
-      test('@import "bar";', ['bar'], scssOpts);
-      test('@import "bar"; @import "foo";', ['bar', 'foo'], scssOpts);
-      test('@import \'bar\';', ['bar'], scssOpts);
-      test('@import \'bar.scss\';', ['bar.scss'], scssOpts);
-      test('@import "_foo.scss";\n@import "_bar.scss";', ['_foo.scss', '_bar.scss'], scssOpts);
-      test('@import "_foo.scss";\n@import "_bar.scss";\n@import "_baz";\n@import "_buttons";', ['_foo.scss', '_bar.scss', '_baz', '_buttons'], scssOpts);
-      test('@import "_nested.scss"; body { color: blue; a { text-decoration: underline; }}', ['_nested.scss'], scssOpts);
-    });
-
-    it('handles comma-separated imports (#2)', function() {
-      test('@import "_foo.scss", "bar";', ['_foo.scss', 'bar'], {
-        syntax: 'scss'
-      });
-    });
-
-    it('allows imports with no semicolon', function() {
-      test('@import "_foo.scss"\n@import "_bar.scss"', ['_foo.scss', '_bar.scss']);
     });
   });
 


### PR DESCRIPTION
That's now in its own module https://github.com/dependents/node-detective-scss
to avoid configuration pain in higher level modules.