### PR TITLE
Update debug to version 4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "mocha": "^5.2.0"
   },
   "dependencies": {
-    "debug": "^3.1.0",
+    "debug": "^4.1.1",
     "gonzales-pe": "^4.2.3",
     "node-source-walk": "^4.0.0"
   }


### PR DESCRIPTION
According to the [release notes](https://github.com/visionmedia/debug/releases/tag/4.0.0) the only breaking change is dropping support for Node.js 4 and 5 which `detective-sass` doesn't support anyway.