### PR TITLE
BREAKING: support scss files too

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,13 @@
 [![npm version](https://img.shields.io/npm/v/detective-sass?logo=npm&logoColor=fff)](https://www.npmjs.com/package/detective-sass)
 [![npm downloads](https://img.shields.io/npm/dm/detective-sass)](https://www.npmjs.com/package/detective-sass)
 
-> Find the dependencies of a sass file
+> Find the dependencies of a sass/scss file
 
 ```sh
 npm install detective-sass
 ```
 
-**Note:** This is specific to the .sass style syntax of the Sass preprocessor. For SCSS support, please see [node-detective-scss](https://github.com/dependents/node-detective-scss).
-
-It's the SASS counterpart to [detective](https://github.com/substack/node-detective), [detective-amd](https://github.com/dependents/node-detective-amd), and [detective-es6](https://github.com/dependents/node-detective-es6).
+It's the SASS/SCSS counterpart to [detective](https://github.com/substack/node-detective), [detective-amd](https://github.com/dependents/node-detective-amd), and [detective-es6](https://github.com/dependents/node-detective-es6).
 
 * The AST is generated using the [gonzales-pe](https://github.com/tonyganch/gonzales-pe) parser.
 
@@ -25,14 +23,15 @@ const detective = require('detective-sass');
 const content = fs.readFileSync('styles.sass', 'utf8');
 
 // list of imported file names (ex: '_foo.sass', '_foo', etc)
-const dependencies = detective(content);
+const dependencies = detective(content, { syntax: 'sass' });
 
 // or to also detect any url() references to images, fonts, etc.
-const allDependencies = detective(content, { url: true });
+const allDependencies = detective(content, { syntax: 'sass', url: true });
 ```
 
 ### Options
 
+* `syntax`: (String) `'sass'` or `'scss'`; which syntax to use.
 * `url` (optional): (`Boolean`) also detect any `url()` references to images, fonts, etc.
 
 ## Related

--- a/index.js
+++ b/index.js
@@ -2,27 +2,31 @@
 
 const { debuglog } = require('util');
 const Walker = require('node-source-walk');
-const sass = require('gonzales-pe');
+const parser = require('gonzales-pe');
 
 const debug = debuglog('detective-sass');
 
 /**
- * Extract the @import statements from a given sass file's content
+ * Extract the @import statements from a given sass/scss file's content
  *
  * @param  {String} content
  * @param  {Object} options
+ * @param  {Boolean} options.syntax - sass or scss
  * @param  {Boolean} options.url - detect any url() references to images, fonts, etc.
  * @return {String[]}
  */
 module.exports = function detective(content, options = {}) {
   if (content === undefined) throw new Error('content not given');
   if (typeof content !== 'string') throw new Error('content is not a string');
+  if (options.syntax === undefined) throw new Error('`options.syntax` not given; possible values are "sass" and "scss"');
+  if (!['sass', 'scss'].includes(options.syntax)) throw new Error('invalid `options.syntax` value; possible values are "sass" and "scss"');
 
   let ast = {};
 
   try {
     debug('content: %s', content);
-    ast = sass.parse(content, { syntax: 'sass' });
+    debug('options: %o', options);
+    ast = parser.parse(content, { syntax: options.syntax });
   } catch (error) {
     debug('parse error: %s', error.message);
   }

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const { suite } = require('uvu');
+const assert = require('uvu/assert');
+const detective = require('../index.js');
+
+const errorSuite = suite('error handling');
+
+errorSuite('throws if options.syntax is missing', () => {
+  assert.throws(() => {
+    detective('');
+  }, err => err instanceof Error && err.message === '`options.syntax` not given; possible values are "sass" and "scss"');
+});
+
+errorSuite('throws if options.syntax is invalid', () => {
+  assert.throws(() => {
+    detective('', { syntax: 'less' });
+  }, err => err instanceof Error && err.message === 'invalid `options.syntax` value; possible values are "sass" and "scss"');
+});
+
+errorSuite('throws if the given content is not a string', () => {
+  assert.throws(() => {
+    detective(() => {});
+  }, err => err instanceof Error && err.message === 'content is not a string');
+});
+
+errorSuite('throws if called with no arguments', () => {
+  assert.throws(() => {
+    detective();
+  }, err => err instanceof Error && err.message === 'content not given');
+});
+
+errorSuite('does not throw for empty files', () => {
+  assert.not.throws(() => {
+    detective('', { syntax: 'sass' });
+  });
+});
+
+errorSuite('does not throw on broken syntax', () => {
+  assert.not.throws(() => {
+    detective('@', { syntax: 'sass' });
+  });
+});
+
+errorSuite('supplies an empty object as the "parsed" ast', () => {
+  detective('|', { syntax: 'sass' });
+  assert.equal(detective.ast, {});
+});
+
+errorSuite.run();

--- a/test/sass.test.js
+++ b/test/sass.test.js
@@ -4,47 +4,15 @@ const { suite } = require('uvu');
 const assert = require('uvu/assert');
 const detective = require('../index.js');
 
-function test(source, dependencies, options) {
-  assert.equal(detective(source, options), dependencies);
+function test(source, dependencies, options = {}) {
+  const mergedOptions = { syntax: 'sass', ...options };
+  assert.equal(detective(source, mergedOptions), dependencies);
 }
-
-const errorSuite = suite('error handling');
-
-errorSuite('does not throw for empty files', () => {
-  assert.not.throws(() => {
-    detective('');
-  });
-});
-
-errorSuite('throws if the given content is not a string', () => {
-  assert.throws(() => {
-    detective(() => {});
-  }, err => err instanceof Error && err.message === 'content is not a string');
-});
-
-errorSuite('throws if called with no arguments', () => {
-  assert.throws(() => {
-    detective();
-  }, err => err instanceof Error && err.message === 'content not given');
-});
-
-errorSuite('does not throw on broken syntax', () => {
-  assert.not.throws(() => {
-    detective('@');
-  });
-});
-
-errorSuite('supplies an empty object as the "parsed" ast', () => {
-  detective('|');
-  assert.equal(detective.ast, {});
-});
-
-errorSuite.run();
 
 const sassSuite = suite('sass');
 
 sassSuite('dangles the parsed AST', () => {
-  detective('@import "_foo.sass";');
+  detective('@import "_foo.sass";', { syntax: 'sass' });
   assert.ok(detective.ast);
 });
 

--- a/test/scss.test.js
+++ b/test/scss.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const { suite } = require('uvu');
+const assert = require('uvu/assert');
+const detective = require('../index.js');
+
+function test(source, dependencies, options = {}) {
+  const mergedOptions = { syntax: 'scss', ...options };
+  assert.equal(detective(source, mergedOptions), dependencies);
+}
+
+const scssSuite = suite('scss');
+
+scssSuite('dangles the parsed AST', () => {
+  detective('@import "_foo.scss";', { syntax: 'scss' });
+  assert.ok(detective.ast);
+});
+
+scssSuite('returns the dependencies of the given .scss file content', () => {
+  test('@import "_foo.scss";', ['_foo.scss']);
+  test('@import        "_foo.scss";', ['_foo.scss']);
+  test('@import "_foo";', ['_foo']);
+  test('body { color: blue; } @import "_foo";', ['_foo']);
+  test('@import "bar";', ['bar']);
+  test('@import "bar"; @import "foo";', ['bar', 'foo']);
+  test('@import \'bar\';', ['bar']);
+  test('@import \'bar.scss\';', ['bar.scss']);
+  test('@import "_foo.scss";\n@import "_bar.scss";', ['_foo.scss', '_bar.scss']);
+  test('@import "_foo.scss";\n@import "_bar.scss";\n@import "_baz";\n@import "_buttons";', ['_foo.scss', '_bar.scss', '_baz', '_buttons']);
+  test('@import "_nested.scss"; body { color: blue; a { text-decoration: underline; }}', ['_nested.scss']);
+});
+
+scssSuite('handles comma-separated imports (#2)', () => {
+  test('@import "_foo.scss", "bar";', ['_foo.scss', 'bar']);
+});
+
+scssSuite('allows imports with no semicolon', () => {
+  test('@import "_foo.scss"\n@import "_bar.scss"', ['_foo.scss', '_bar.scss']);
+});
+
+scssSuite('returns the url dependencies when enable url', () => {
+  test(
+    '@font-face { font-family: "Trickster"; src: local("Trickster"), url("trickster-COLRv1.otf") format("opentype") tech(color-COLRv1), url("trickster-outline.otf") format("opentype"), url("trickster-outline.woff") format("woff"); }',
+    [
+      'trickster-COLRv1.otf',
+      'trickster-outline.otf',
+      'trickster-outline.woff'
+    ],
+    { url: true }
+  );
+
+  test(
+    'body { div {background: no-repeat center/80% url("foo.png"); }}',
+    ['foo.png'],
+    { url: true }
+  );
+
+  test(
+    'body { div {background: no-repeat center/80% url(foo.png); }}',
+    ['foo.png'],
+    { url: true }
+  );
+});
+
+scssSuite.run();


### PR DESCRIPTION
`options.syntax` is now required; can be either 'sass' or 'scss'